### PR TITLE
Add extension method AddVostok for ILoggerBuilder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-## 2.0.2 (19.12.19):
+## 2.0.3 (23.12.2019)
+Create `loggerFactory.AddVostok(log)` extension method
+
+## 2.0.2 (19.12.2019):
 Added `VostokLoggerProviderSettings` that allows to ignore some scopes.
 
 ## 2.0.0 (26.06.2019):

--- a/Vostok.Logging.Microsoft/Vostok.Logging.Microsoft.csproj
+++ b/Vostok.Logging.Microsoft/Vostok.Logging.Microsoft.csproj
@@ -22,7 +22,7 @@
     <RepositoryUrl>https://github.com/vostok/logging.microsoft</RepositoryUrl>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Vostok.Logging.Abstractions">

--- a/Vostok.Logging.Microsoft/VostokLoggerExtensions.cs
+++ b/Vostok.Logging.Microsoft/VostokLoggerExtensions.cs
@@ -19,5 +19,15 @@ namespace Vostok.Logging.Microsoft
             factory.AddProvider(new VostokLoggerProvider(log));
             return factory;
         }
+
+        /// <summary>
+        /// <para>Add a new <see cref="VostokLoggerProvider"/> for given root <paramref name="log"/> to the <paramref name="builder"/></para>
+        /// </summary>
+        [NotNull]
+        public static ILoggingBuilder AddVostok([NotNull] this ILoggingBuilder builder, [NotNull] ILog log)
+        {
+            builder.AddProvider(new VostokLoggerProvider(log));
+            return builder;
+        }
     }
 }


### PR DESCRIPTION
This makes possible to add vostok logging like WebHost.CreateDefaultBuilder().ConfigureLogging(x => x.AddVostok(log)).

It feels like more idiomatic place to add logging providers. Exisitng extension method for ILoggingFactory is only available in `Startup.Configure` phase.