### PR TITLE
Log all composite scope variables

### DIFF
--- a/Vostok.Logging.Microsoft/VostokLoggerProvider.cs
+++ b/Vostok.Logging.Microsoft/VostokLoggerProvider.cs
@@ -98,7 +98,7 @@ namespace Vostok.Logging.Microsoft
                     return new EmptyDisposable();
 
                 var scopeValue = state == null ? scopeName : Convert.ToString(state);
-                var scopeLog = log.WithOperationContext();
+                var scopeLog = scope.Value?.Log ?? log.WithOperationContext();
 
                 if (state is IEnumerable<KeyValuePair<string, object>> props)
                 {


### PR DESCRIPTION
Current implementation logs only last scope based on IEnumerable<KeyValuePair<string, object>> as previous being overridden by subsequent calls