### PR TITLE
add MicrosoftVostokLogAdapter

### DIFF
--- a/Vostok.Logging.Microsoft/Adapters/MicrosoftVostokLogAdapter.cs
+++ b/Vostok.Logging.Microsoft/Adapters/MicrosoftVostokLogAdapter.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using JetBrains.Annotations;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Internal;
+using Vostok.Logging.Abstractions;
+using Vostok.Logging.Abstractions.Wrappers;
+using Vostok.Logging.Formatting;
+using VostokLogLevel = Vostok.Logging.Abstractions.LogLevel;
+using MicrosoftLogLevel = Microsoft.Extensions.Logging.LogLevel;
+
+namespace Vostok.Logging.Microsoft.Adapters
+{
+    [PublicAPI]
+    public sealed class MicrosoftVostokLogAdapter : ILog
+    {
+        private const int NullEventId = 0;
+        private readonly Func<FormattedLogValues, Exception, string> messageFormatter = MessageFormatter;
+
+        private readonly ILogger logger;
+        private readonly OutputTemplate template = OutputTemplate.Parse(
+            $"{{{WellKnownProperties.TraceContext}:w}}" +
+            $"{{{WellKnownProperties.OperationContext}:w}}" +
+            $"{{{WellKnownProperties.SourceContext}:w}}" +
+            $"{{{WellKnownTokens.Message}}}");
+
+        public MicrosoftVostokLogAdapter(ILogger logger)
+        {
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
+        }
+
+        public void Log(LogEvent @event)
+        {
+            if (@event is null)
+                return;
+
+            if (!IsEnabledFor(@event.Level))
+                return;
+
+            var logLevel = ConvertLogLevel(@event.Level);
+            var message = LogEventFormatter.Format(@event, template);
+            var state = new FormattedLogValues(message, Array.Empty<object>());
+
+            logger.Log(logLevel, NullEventId, state, @event.Exception, messageFormatter);
+        }
+
+        private static string MessageFormatter(FormattedLogValues state, Exception error)
+        {
+            return state.ToString();
+        }
+
+        public bool IsEnabledFor(VostokLogLevel level)
+        {
+            var logLevel = ConvertLogLevel(level);
+            return logger.IsEnabled(logLevel);
+        }
+
+        public ILog ForContext(string context)
+        {
+            return new SourceContextWrapper(this, context);
+        }
+
+        private static MicrosoftLogLevel ConvertLogLevel(VostokLogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case VostokLogLevel.Debug:
+                    return MicrosoftLogLevel.Debug;
+                case VostokLogLevel.Info:
+                    return MicrosoftLogLevel.Information;
+                case VostokLogLevel.Warn:
+                    return MicrosoftLogLevel.Warning;
+                case VostokLogLevel.Error:
+                    return MicrosoftLogLevel.Error;
+                case VostokLogLevel.Fatal:
+                    return MicrosoftLogLevel.Critical;
+                default:
+                    return MicrosoftLogLevel.None;
+            }
+        }
+    }
+}

--- a/Vostok.Logging.Microsoft/MicrosoftLogSettings.cs
+++ b/Vostok.Logging.Microsoft/MicrosoftLogSettings.cs
@@ -1,0 +1,10 @@
+﻿using JetBrains.Annotations;
+
+namespace Vostok.Logging.Microsoft
+{
+    [PublicAPI]
+    public class MicrosoftLogSettings
+    {
+        public bool UseVostokTemplate { get; set; }
+    }
+}

--- a/Vostok.Logging.Microsoft/Vostok.Logging.Microsoft.csproj
+++ b/Vostok.Logging.Microsoft/Vostok.Logging.Microsoft.csproj
@@ -36,5 +36,9 @@
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\vostok.logging.context\Vostok.Logging.Context\bin\Release\netstandard2.0\Vostok.Logging.Context.dll</HintPath>
     </Reference>
+    <Reference Include="Vostok.Logging.Formatting">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\vostok.logging.formatting\Vostok.Logging.Formatting\bin\Release\netstandard2.0\Vostok.Logging.Formatting.dll</HintPath>
+    </Reference>
   </ItemGroup>
 </Project>

--- a/module.yaml
+++ b/module.yaml
@@ -12,6 +12,7 @@ notests *default:
     - vostok.devtools
     - vostok.logging.abstractions
     - vostok.logging.context
+    - vostok.logging.formatting
     - vostok.commons.helpers/src
 
 full-build > notests:


### PR DESCRIPTION
Hi, our team usually builds projects with `microsoft.aspnetcore.*` and `microsoft.extensions.*` frameworks but API's clients are based on `Vostok.ClusterClient*` library. 

It looks nice but we have to use own adapter
`Microsoft.Extensions.Logging.ILogger --> Vostok.Logging.Abstractions.ILog`.

--
We have an option to create an additional library and provide this adapter but i think it will be useful for others who use `vostok.logging.microsoft` in a similar case.