### PR TITLE
Add CreateLog extension method

### DIFF
--- a/Vostok.Logging.Microsoft/PublicAPI.Shipped.txt
+++ b/Vostok.Logging.Microsoft/PublicAPI.Shipped.txt
@@ -7,7 +7,7 @@ const Vostok.Logging.Microsoft.Helpers.MicrosoftLogScopes.HostingLogScopeOld = "
 const Vostok.Logging.Microsoft.Helpers.MicrosoftLogScopes.ViewComponentLogScope = "Microsoft.AspNetCore.Mvc.ViewFeatures.MvcViewFeaturesLoggerExtensions+ViewComponentLogScope" -> string
 static Vostok.Logging.Microsoft.VostokLoggerExtensions.AddVostok(this Microsoft.Extensions.Logging.ILoggerFactory factory, Vostok.Logging.Abstractions.ILog log) -> Microsoft.Extensions.Logging.ILoggerFactory
 static Vostok.Logging.Microsoft.VostokLoggerExtensions.AddVostok(this Microsoft.Extensions.Logging.ILoggingBuilder builder, Vostok.Logging.Abstractions.ILog log) -> Microsoft.Extensions.Logging.ILoggingBuilder
-static Vostok.Logging.Microsoft.VostokLoggerExtensions.CreateLog(this Microsoft.Extensions.Logging.ILoggerFactory factory, string categoryName) -> Vostok.Logging.Microsoft.MicrosoftLog
+static Vostok.Logging.Microsoft.VostokLoggerExtensions.CreateVostokMicrosoftLog(this Microsoft.Extensions.Logging.ILoggerFactory factory, string categoryName) -> Vostok.Logging.Microsoft.MicrosoftLog
 Vostok.Logging.Microsoft.Helpers.MicrosoftLogScopes
 Vostok.Logging.Microsoft.MicrosoftLog
 Vostok.Logging.Microsoft.MicrosoftLog.ForContext(string context) -> Vostok.Logging.Abstractions.ILog

--- a/Vostok.Logging.Microsoft/PublicAPI.Shipped.txt
+++ b/Vostok.Logging.Microsoft/PublicAPI.Shipped.txt
@@ -7,6 +7,7 @@ const Vostok.Logging.Microsoft.Helpers.MicrosoftLogScopes.HostingLogScopeOld = "
 const Vostok.Logging.Microsoft.Helpers.MicrosoftLogScopes.ViewComponentLogScope = "Microsoft.AspNetCore.Mvc.ViewFeatures.MvcViewFeaturesLoggerExtensions+ViewComponentLogScope" -> string
 static Vostok.Logging.Microsoft.VostokLoggerExtensions.AddVostok(this Microsoft.Extensions.Logging.ILoggerFactory factory, Vostok.Logging.Abstractions.ILog log) -> Microsoft.Extensions.Logging.ILoggerFactory
 static Vostok.Logging.Microsoft.VostokLoggerExtensions.AddVostok(this Microsoft.Extensions.Logging.ILoggingBuilder builder, Vostok.Logging.Abstractions.ILog log) -> Microsoft.Extensions.Logging.ILoggingBuilder
+static Vostok.Logging.Microsoft.VostokLoggerExtensions.CreateLog(this Microsoft.Extensions.Logging.ILoggerFactory factory, string categoryName) -> Vostok.Logging.Microsoft.MicrosoftLog
 Vostok.Logging.Microsoft.Helpers.MicrosoftLogScopes
 Vostok.Logging.Microsoft.MicrosoftLog
 Vostok.Logging.Microsoft.MicrosoftLog.ForContext(string context) -> Vostok.Logging.Abstractions.ILog

--- a/Vostok.Logging.Microsoft/VostokLoggerExtensions.cs
+++ b/Vostok.Logging.Microsoft/VostokLoggerExtensions.cs
@@ -34,7 +34,7 @@ namespace Vostok.Logging.Microsoft
         /// <para>Create a new <see cref="MicrosoftLog"/> with given <paramref name="categoryName"/> from the <paramref name="factory"/></para>
         /// </summary>
         [NotNull]
-        public static MicrosoftLog CreateLog([NotNull] this ILoggerFactory factory, string categoryName)
+        public static MicrosoftLog CreateVostokMicrosoftLog([NotNull] this ILoggerFactory factory, string categoryName)
         {
             var logger = factory.CreateLogger(categoryName);
             return new MicrosoftLog(logger);

--- a/Vostok.Logging.Microsoft/VostokLoggerExtensions.cs
+++ b/Vostok.Logging.Microsoft/VostokLoggerExtensions.cs
@@ -29,5 +29,15 @@ namespace Vostok.Logging.Microsoft
             builder.AddProvider(new VostokLoggerProvider(log));
             return builder;
         }
+
+        /// <summary>
+        /// <para>Create a new <see cref="MicrosoftLog"/> with given <paramref name="categoryName"/> from the <paramref name="factory"/></para>
+        /// </summary>
+        [NotNull]
+        public static MicrosoftLog CreateLog([NotNull] this ILoggerFactory factory, string categoryName)
+        {
+            var logger = factory.CreateLogger(categoryName);
+            return new MicrosoftLog(logger);
+        }
     }
 }


### PR DESCRIPTION
If we want to create an ILog from an ILoggerFactory we can't skip creation of an ILogger. That's why I think we can wrap this logic into the extension method.